### PR TITLE
Vagrant workaround fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,6 +68,7 @@ Vagrant.configure(2) do |config|
   config.vm.provider "virtualbox"
   config.vm.provider "vmware_fusion"
   config.vm.box = "CiscoCloud/mantl"
+  config.ssh.insert_key = false
 
   # Disable shared folder(s) for non-provisioning machines
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/roles/mesos/tasks/main.yml
+++ b/roles/mesos/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: remove mesos
+  sudo: yes
+  yum:
+    name: mesos
+    state: absent
+
 - name: install mesos packages
   sudo: yes
   yum:


### PR DESCRIPTION
Small workaround fixes to get `vagrant up` to work. These fixes are not long term.
- Next version of Vagrant v1.8.6 should have fixed its bug a/c to https://github.com/CiscoCloud/mantl/issues/1829
- Conflicting Mesos versions should be addressed in the Vagrant base box built by Packer