### PR TITLE
Fix duplicate variables in iam definitions.

### DIFF
--- a/terraform/aws/iam/control-profile.tf
+++ b/terraform/aws/iam/control-profile.tf
@@ -1,5 +1,3 @@
-variable "short_name" {default = "mantl"}
-
 resource "aws_iam_instance_profile" "control_profile" {
   name = "${var.short_name}-control-profile"
   roles = ["${aws_iam_role.control_role.name}"]

--- a/terraform/aws/iam/variables.tf
+++ b/terraform/aws/iam/variables.tf
@@ -1,0 +1,1 @@
+variable "short_name" {default = "mantl"}

--- a/terraform/aws/iam/worker-profile.tf
+++ b/terraform/aws/iam/worker-profile.tf
@@ -1,5 +1,3 @@
-variable "short_name" {default = "mantl"}
-
 resource "aws_iam_instance_profile" "worker_profile" {
   name = "${var.short_name}-worker-profile"
   roles = ["${aws_iam_role.worker_role.name}"]


### PR DESCRIPTION
Simple fix for duplicate variables in terraform defs! which fails in `terraform >= 0.7.3`
