### PR TITLE
edge needs 443 to be open

### DIFF
--- a/terraform/aws/security_groups/main.tf
+++ b/terraform/aws/security_groups/main.tf
@@ -116,8 +116,8 @@ resource "aws_security_group" "edge" {
   }
 
   ingress { # HTTP
-    from_port = 80
-    to_port = 80
+    from_port = 8080
+    to_port = 8080
     protocol = "tcp"
     cidr_blocks = ["${split(",",var.ingress_cidr_blocks)}"]
   }
@@ -127,6 +127,13 @@ resource "aws_security_group" "edge" {
     to_port = 443
     protocol = "tcp"
     cidr_blocks = ["${split(",",var.ingress_cidr_blocks)}"]
+  }
+
+  ingress { # HTTPS world
+    from_port = 443
+    to_port = 443
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }
 


### PR DESCRIPTION
gateway container service now listens on 8080