### PR TITLE
Fix multiple issues with mantl UI, TF and Ansible

### DIFF
--- a/roles/mantlui/defaults/main.yml
+++ b/roles/mantlui/defaults/main.yml
@@ -1,4 +1,4 @@
 mantlui_nginx_image: ciscocloud/nginx-mantlui
-mantlui_nginx_image_tag: 0.7.1
+mantlui_nginx_image_tag: 0.7.2
 do_mantlui_ssl: false
 do_mantlui_auth: false

--- a/roles/vault/tasks/tls-auth.yml
+++ b/roles/vault/tasks/tls-auth.yml
@@ -4,6 +4,7 @@
   run_once: yes
   command: vault auth {{ vault_command_options }} {{ vault_token }}
   changed_when: false
+  when: vault_token is defined
   tags:
     - vault
 
@@ -13,6 +14,7 @@
   command: vault auth-enable {{ vault_command_options }} cert
   register: vault_enable_cert
   ignore_errors: yes
+  when: vault_token is defined
   failed_when: >
     {{ vault_enable_cert.rc != 0
     and 'path is already in use' not in vault_enable_cert.stderr }}
@@ -27,6 +29,7 @@
     auth/cert/certs/mantl-ca
     display_name=mantl-ca
     certificate=@/etc/pki/CA/ca.cert
+  when: vault_token is defined
   tags:
     - vault
 
@@ -34,5 +37,6 @@
   sudo: yes
   command: vault auth {{ vault_command_options }} --method=cert
   changed_when: false
+  when: vault_token is defined
   tags:
     - vault

--- a/terraform/aws/instance/main.tf
+++ b/terraform/aws/instance/main.tf
@@ -62,6 +62,10 @@ resource "aws_volume_attachment" "instance-lvm-attachment" {
   instance_id = "${element(aws_instance.instance.*.id, count.index)}"
   volume_id = "${element(aws_ebs_volume.ebs.*.id, count.index)}"
   force_detach = true
+
+  lifecycle {
+    ignore_changes = [ "volume_id", "instance_id" ]
+  }
 }
 
 


### PR DESCRIPTION
This PR is a combination of:
- `tf-aws-vol-reattach-workaround` branch (commit f1532504be16dd3452afdad21ea21e6d598f7bbf)
- `fix/update-mantl-ui` branch (commit 720f7a844cb123ea2351523abb51a7633e19d079)
- Ansible rerun fix (commit ffdb32fc8128426394bf4378725d8533cb211b80)

It would have been inefficient to test all these separately, so I'm combining it into single PR.