### PR TITLE
add gc flags to default mesos agent confs

### DIFF
--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -16,6 +16,8 @@ mesos_leader_cmd: mesos-master
 mesos_follower_cmd: mesos-slave
 mesos_executor_registration_timeout: 10mins
 mesos_isolation: cgroups/cpu,cgroups/mem
+mesos_gc_delay: 1weeks
+mesos_gc_disk_headroom: .2
 
 mesos_resources:
   - "ports(*):[4000-5000, 7000-8000, 9000-10000, 25000-26000, 31000-32000]"

--- a/roles/mesos/templates/mesos-agent.sysconfig.j2
+++ b/roles/mesos/templates/mesos-agent.sysconfig.j2
@@ -17,6 +17,8 @@ MESOS_CONTAINERIZERS=docker,mesos
 MESOS_EXECUTOR_REGISTRATION_TIMEOUT={{ mesos_executor_registration_timeout }}
 MESOS_WORK_DIR={{ mesos_work_dir }}
 MESOS_ISOLATION={{ mesos_isolation }}
+MESOS_GC_DELAY={{ mesos_gc_delay }}
+MESOS_GC_DISK_HEADROOM={{ mesos_gc_disk_headroom }}
 
 # authentication
 {% if not (do_mesos_follower_auth|bool) %}# {% endif %}MESOS_CREDENTIAL=file:///etc/sysconfig/mesos-agent-credential


### PR DESCRIPTION
This PR introduces changes to allow us to configure mesos gc confs:
```
--gc-delay
--gc-disk-headroom
```

gc delay sets the interval from 1week to 2days. we should discuss this and test this before settling on a value.

gc disk headroom sets the threshold on a slave for max disk utilization before mesos gc kicks in regardless of `--gc-delay`.

not sure of how we best test this etc. and will need some guidance on that front.

