### PR TITLE
Fix broken deps for Mantl DNS package

### DIFF
--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -1,10 +1,8 @@
 ---
 - name: download custom mantl-dns rpm
-  s3:
-    bucket: ds-site-static-assets
-    object: /systems/mantl-dns-1.1.0-custombuild-ds.centos.x86_64.rpm
-    dest: /tmp/systems/mantl-dns-1.1.0-custombuild-ds.centos.x86_64.rpm
-    mode: get
+  get_url:
+    url: http://ds-site-static-assets.s3.amazonaws.com/systems/mantl-dns-1.1.0-custombuild-ds.centos.x86_64.rpm  
+    dest: /tmp/mantl-dns-1.1.0-custombuild-ds.centos.x86_64.rpm
   tags:
     - dnsmasq
 

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -1,8 +1,17 @@
 ---
+- name: download custom mantl-dns rpm
+  s3:
+    bucket: ds-site-static-assets
+    object: /systems/mantl-dns-1.1.0-custombuild-ds.centos.x86_64.rpm
+    dest: /tmp/systems/mantl-dns-1.1.0-custombuild-ds.centos.x86_64.rpm
+    mode: get
+  tags:
+    - dnsmasq
+
 - name: install mantl-dns
-  sudo: yes
+  become: yes
   yum:
-    name: "mantl-dns-{{ mantl_dns_version }}"
+    name: /tmp/mantl-dns-1.1.0-custombuild-ds.centos.x86_64.rpm
     state: installed
   tags:
     - dnsmasq

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 - name: download custom mantl-dns rpm
   get_url:
-    url: http://ds-site-static-assets.s3.amazonaws.com/systems/mantl-dns-1.1.0-custombuild-ds.centos.x86_64.rpm  
-    dest: /tmp/mantl-dns-1.1.0-custombuild-ds.centos.x86_64.rpm
+    url: http://ds-site-static-assets.s3.amazonaws.com/systems/mantl-dns-1.1.0-6.centos.x86_64.rpm  
+    dest: /tmp/mantl-dns-1.1.0-6.centos.x86_64.rpm
   tags:
     - dnsmasq
 
 - name: install mantl-dns
   become: yes
   yum:
-    name: /tmp/mantl-dns-1.1.0-custombuild-ds.centos.x86_64.rpm
+    name: /tmp/mantl-dns-1.1.0-6.centos.x86_64.rpm
     state: installed
   tags:
     - dnsmasq


### PR DESCRIPTION
`mantl-dns` package has a broken dep chain due to change in version of `NetworkManager` in upstream yum repos. 

Fixed by baking our own RPM w/ updated version of `NetworkManager` here https://github.com/datascienceinc/mantl-packaging/commit/baa2a916f8913aa31aa210e61e9d6a8cd483da28 and pushed to S3.

**The change in this PR is to use the RPM we baked instead of the version of package in remote yum repo.**

Ansible Error:
```
TASK [mantl-roles/roles/dnsmasq : install mantl-dns] ***************************
fatal: [experimental-worker-003]: FAILED! => {"changed": true, "failed": true, "msg": "Error: Package: mant
l-dns-1.1.0-5.centos.x86_64 (asteris-mantl-rpm)\n           Requires: NetworkManager = 1:1.0.6\n
Available: 1:NetworkManager-1.4.0-12.el7.x86_64 (base)\n               NetworkManager = 1:1.4.0-12.el7\n
        Available: 1:NetworkManager-1.4.0-13.el7_3.x86_64 (updates)\n               NetworkManager = 1:1.4.
0-13.el7_3\n", "rc": 1, "results": ["Loaded plugins: fastestmirror\nLoading mirror speeds from cached hostf
ile\n * base: mirror.web-ster.com\n * epel: s3-mirror-us-west-2.fedoraproject.org\n * extras: mirror.linuxf
ix.com\n * updates: mirror.tocici.com\nResolving Dependencies\n--> Running transaction check\n---> Package
mantl-dns.x86_64 0:1.1.0-5.centos will be installed\n--> Processing Dependency: NetworkManager = 1:1.0.6 fo
r package: mantl-dns-1.1.0-5.centos.x86_64\n--> Processing Dependency: bind-utils = 32:9.9.4 for package: m
antl-dns-1.1.0-5.centos.x86_64\n--> Running transaction check\n---> Package bind-utils.x86_64 32:9.9.4-38.e
l7_3 will be installed\n--> Processing Dependency: bind-libs = 32:9.9.4-38.el7_3 for package: 32:bind-utils
-9.9.4-38.el7_3.x86_64\n--> Processing Dependency: liblwres.so.90()(64bit) for package: 32:bind-utils-9.9.4
-38.el7_3.x86_64\n--> Processing Dependency: libisccfg.so.90()(64bit) for package: 32:bind-utils-9.9.4-38.e
l7_3.x86_64\n--> Processing Dependency: libisccc.so.90()(64bit) for package: 32:bind-utils-9.9.4-38.el7_3.x
86_64\n--> Processing Dependency: libisc.so.95()(64bit) for package: 32:bind-utils-9.9.4-38.el7_3.x86_64\n-
-> Processing Dependency: libdns.so.100()(64bit) for package: 32:bind-utils-9.9.4-38.el7_3.x86_64\n--> Proc
essing Dependency: libbind9.so.90()(64bit) for package: 32:bind-utils-9.9.4-38.el7_3.x86_64\n--> Processing
 Dependency: libGeoIP.so.1()(64bit) for package: 32:bind-utils-9.9.4-38.el7_3.x86_64\n---> Package mantl-dn
s.x86_64 0:1.1.0-5.centos will be installed\n--> Processing Dependency: NetworkManager = 1:1.0.6 for packag
e: mantl-dns-1.1.0-5.centos.x86_64\n--> Running transaction check\n---> Package GeoIP.x86_64 0:1.5.0-11.el7
 will be installed\n---> Package bind-libs.x86_64 32:9.9.4-38.el7_3 will be installed\n--> Processing Depen
dency: bind-license = 32:9.9.4-38.el7_3 for package: 32:bind-libs-9.9.4-38.el7_3.x86_64\n---> Package mantl
-dns.x86_64 0:1.1.0-5.centos will be installed\n--> Processing Dependency: NetworkManager = 1:1.0.6 for pac
kage: mantl-dns-1.1.0-5.centos.x86_64\n--> Running transaction check\n---> Package bind-license.noarch 32:9
.9.4-29.el7_2.2 will be updated\n--> Processing Dependency: bind-license = 32:9.9.4-29.el7_2.2 for package:
 32:bind-libs-lite-9.9.4-29.el7_2.2.x86_64\n---> Package bind-license.noarch 32:9.9.4-38.el7_3 will be an u
pdate\n---> Package mantl-dns.x86_64 0:1.1.0-5.centos will be installed\n--> Processing Dependency: Network
Manager = 1:1.0.6 for package: mantl-dns-1.1.0-5.centos.x86_64\n--> Running transaction check\n---> Package
 bind-libs-lite.x86_64 32:9.9.4-29.el7_2.2 will be updated\n---> Package bind-libs-lite.x86_64 32:9.9.4-38.
el7_3 will be an update\n---> Package mantl-dns.x86_64 0:1.1.0-5.centos will be installed\n--> Processing D
ependency: NetworkManager = 1:1.0.6 for package: mantl-dns-1.1.0-5.centos.x86_64\n--> Finished Dependency R
esolution\n You could try using --skip-broken to work around the problem\n You could try running: rpm -Va -
-nofiles --nodigest\n"]}
```